### PR TITLE
RSDK-9046 Add L2CapDisconnectedError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.0.3
+
+Add and return L2CapDisconnectedError when L2CAP disconnection is detected.
+
 # 0.0.2
 
 Podspec changes ble->blev.

--- a/lib/ble.dart
+++ b/lib/ble.dart
@@ -1,4 +1,4 @@
 /// Shared types to be used by ble_central, ble_peripheral, and ble_socket.
 library ble;
 
-export 'src/ble.dart' show AdapterState, L2CapChannel;
+export 'src/ble.dart' show AdapterState, L2CapChannel, L2CapDisconnectedError;

--- a/lib/src/ble.dart
+++ b/lib/src/ble.dart
@@ -183,6 +183,19 @@ enum AdapterState {
   }
 }
 
+/// Error indicating that relevant L2Cap COC is disconnected.
+class L2CapDisconnectedError extends Error {
+  final String _message;
+
+  /// Creates a new L2CapDisconnectedError.
+  L2CapDisconnectedError(this._message);
+
+  @override
+  String toString() {
+    return 'L2CapDisconnectedError: $_message';
+  }
+}
+
 /// A simple, raw read and write wrapper around an L2CAP COC.
 abstract class L2CapChannel {
   /// Writes to the channel and returns how much was written.

--- a/lib/src/ble.dart
+++ b/lib/src/ble.dart
@@ -183,7 +183,7 @@ enum AdapterState {
   }
 }
 
-/// Error indicating that relevant L2Cap COC is disconnected.
+/// Error indicating that the relevant L2Cap COC is disconnected.
 class L2CapDisconnectedError extends Error {
   final String _message;
 

--- a/lib/src/ble_channel_socket_mux.dart
+++ b/lib/src/ble_channel_socket_mux.dart
@@ -142,10 +142,11 @@ abstract class _L2CapChannelSocketMultiplexer {
         await _channel.write(pkt);
       }
     } catch (err) {
-      if (!_completer.isCompleted) {
-        debugPrint('error sending keep alive frames into l2cap channel: $err');
-      }
       await close();
+      // Assume that a failure to write a keepalive indicates a closed L2Cap
+      // COC. Throw custom error that can be caught in application code to
+      // execute custom reconnection logic.
+      throw L2CapDisconnectedError('keepalive failed to send: $err');
     }
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: blev
 description: A flutter plugin to communicate with Bluetooth Low Energy devices.
 repository: https://github.com/viamrobotics/flutter-ble
-version: 0.0.2
+version: 0.0.3
 homepage: https://viam.com
 topics:
   - bluetooth


### PR DESCRIPTION
Adds an `L2CapDisconnectedError` that can be caught to implement custom reconnect logic. Throws the error when a keepalive fails to send into the L2Cap COC.

Seems like ios, at least, has no great way of determining whether an L2CAP channel has closed (unless we did the closing ourselves). We will have to rely on a failure to send data across the channel as an indication of its closure. We do something similar in the socks-forwarder code, too (failure to read indicates closure).

New error utilized in https://github.com/viam-labs/ble-managed/pull/4.