### PR TITLE
RSDK-10051 - Throw and catch timeout exception for connection time outs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.0.4
+
+Throw and catch timeout exception for connection time outs.
+
 # 0.0.3
 
 Add and return L2CapDisconnectedError when L2CAP disconnection is detected.

--- a/android/src/main/kotlin/com/viam/ble/Peripheral.kt
+++ b/android/src/main/kotlin/com/viam/ble/Peripheral.kt
@@ -193,7 +193,7 @@ class Peripheral(
                 } else {
                     disconnected = true
                     val exceptionStr = "failed to connect to device: ${device.name} ${device.address} with GATT status: $status state: $newState"
-                    // 147 corresponds to GATT_CONNECTION_TIMEOUT but that was introduced in API level 35, so doing a straight
+                    // 147 corresponds to GATT_CONNECTION_TIMEOUT but that constant was only introduced in API level 35, so doing a straight
                     // comparison instead.
                     if (status == 147) {
                         connectedContinuation?.resumeWithException(TimeoutException(exceptionStr))

--- a/android/src/main/kotlin/com/viam/ble/Peripheral.kt
+++ b/android/src/main/kotlin/com/viam/ble/Peripheral.kt
@@ -21,6 +21,7 @@ import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import java.util.UUID
+import java.util.concurrent.TimeoutException
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 
@@ -185,13 +186,20 @@ class Peripheral(
                 status: Int,
                 newState: Int,
             ) {
-                Log.d(TAG, "onConnectionStateChange $status $newState")
+                Log.d(TAG, "onConnectionStateChange status: $status state: $newState device: ${device.name} ${device.address}")
                 if (newState == BluetoothProfile.STATE_CONNECTED) {
                     requireNotNull(gatt)
                     gatt.discoverServices()
                 } else {
                     disconnected = true
-                    connectedContinuation?.resumeWithException(Exception("failed to connect with GATT status: $status state: $newState"))
+                    val exceptionStr = "failed to connect to device: ${device.name} ${device.address} with GATT status: $status state: $newState"
+                    // 147 corresponds to GATT_CONNECTION_TIMEOUT but that was introduced in API level 35, so doing a straight
+                    // comparison instead.
+                    if (status == 147) {
+                        connectedContinuation?.resumeWithException(TimeoutException(exceptionStr))
+                    } else {
+                        connectedContinuation?.resumeWithException(Exception(exceptionStr))
+                    }
                     connectedContinuation = null
                     val disconnectRequested = disconnectedContinuation != null
                     disconnectedContinuation?.resume(Unit)

--- a/example/peripheral_socks_server/pubspec.yaml
+++ b/example/peripheral_socks_server/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  ble: 
+  blev: 
     path: ../../
   permission_handler: ^11.3.1
   socks5_proxy: ^1.0.6

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: blev
 description: A flutter plugin to communicate with Bluetooth Low Energy devices.
 repository: https://github.com/viamrobotics/flutter-ble
-version: 0.0.3
+version: 0.0.4
 homepage: https://viam.com
 topics:
   - bluetooth


### PR DESCRIPTION
also adds more debug info

error messages go from
```
D/BlePlugin(14227): failed to connect to bonded device XX:XX:XX:XX:6F:49
D/BlePlugin(14227): java.lang.Exception: failed to connect with GATT status: 147 state: 0
D/BlePlugin(14227):     at com.viam.ble.Peripheral$bluetoothGattCallback$1.onConnectionStateChange(Peripheral.kt:194)
D/BlePlugin(14227):     at android.bluetooth.BluetoothGatt$1$4.run(BluetoothGatt.java:389)
D/BlePlugin(14227):     at android.bluetooth.BluetoothGatt.runOrQueueCallback(BluetoothGatt.java:1068)
D/BlePlugin(14227):     at android.bluetooth.BluetoothGatt.-$$Nest$mrunOrQueueCallback(Unknown Source:0)
D/BlePlugin(14227):     at android.bluetooth.BluetoothGatt$1.onClientConnectionState(BluetoothGatt.java:383)
D/BlePlugin(14227):     at android.bluetooth.IBluetoothGattCallback$Stub.onTransact(IBluetoothGattCallback.java:209)
D/BlePlugin(14227):     at android.os.Binder.execTransactInternal(Binder.java:1396)
D/BlePlugin(14227):     at android.os.Binder.execTransact(Binder.java:1335)
```
to 
```
D/BluetoothGattServer(20778): onServerConnectionState() - status=0 serverIf=16 connected=false device=XX:XX:XX:XX:6F:49
D/BluetoothGatt(20778): onClientConnectionState() - status=147 clientIf=17 connected=false device=XX:XX:XX:XX:6F:49
D/BlePlugin(20778): onConnectionStateChange status: 147 state: 0 device: WH-1000XM4 XX:XX:XX:XX:6F:49
D/BlePlugin(20778): timed out trying to connect to bonded device WH-1000XM4 XX:XX:XX:XX:6F:49
D/BlePlugin(20778): connecting to bonded device WH-1000XM4 XX:XX:XX:XX:6F:49 to see if it has desired service(s)
```