### PR TITLE
Avoid bluetooth permission request on launch

### DIFF
--- a/ios/Classes/CentralManager.swift
+++ b/ios/Classes/CentralManager.swift
@@ -15,6 +15,10 @@ public class CentralManager: NSObject {
     private var peripherals: [String: Peripheral] = [:]
     private var peripheralsLock: NSLock = NSLock()
 
+    private override init() {
+        super.init()
+    }
+
     public func reset() async {
         if self.manager.state == CBManagerState.poweredOn {
             do {

--- a/ios/Classes/CentralManager.swift
+++ b/ios/Classes/CentralManager.swift
@@ -7,20 +7,13 @@ import Foundation
 public class CentralManager: NSObject {
     static let singleton = CentralManager()
 
-    private var actualManager: CBCentralManager?
-    private var manager: CBCentralManager {
-        // This force unwrap is okay
-        return actualManager!
-    }
+    private lazy var manager: CBCentralManager = {
+        return CBCentralManager(delegate: self, queue: managerQueue)
+    }()
 
     private var managerQueue = DispatchQueue.global(qos: .utility)
     private var peripherals: [String: Peripheral] = [:]
     private var peripheralsLock: NSLock = NSLock()
-
-    private override init() {
-        super.init()
-        actualManager = CBCentralManager(delegate: self, queue: managerQueue)
-    }
 
     public func reset() async {
         if self.manager.state == CBManagerState.poweredOn {
@@ -115,8 +108,9 @@ public class CentralManager: NSObject {
     }
 }
 
-extension CentralManager: CBCentralManagerDelegate {
+// MARK: - CBCentralManagerDelegate
 
+extension CentralManager: CBCentralManagerDelegate {
     public func centralManagerDidUpdateState(_ central: CBCentralManager) {
         let userInfo = makeAdapterState(state: central.state)
         NotificationCenter.default.post(

--- a/ios/Classes/PeripheralManager.swift
+++ b/ios/Classes/PeripheralManager.swift
@@ -22,6 +22,10 @@ public class PeripheralManager: NSObject {
     private var servicesToAdvertise: [CBMutableService] = []
     private var servicesToAdvertiseLock: NSLock = NSLock()
 
+    private override init() {
+        super.init()
+    }
+
     public func reset() async {
         self.manager.removeAllServices()
         self.servicesToAdvertiseLock.withLock {

--- a/ios/Classes/PeripheralManager.swift
+++ b/ios/Classes/PeripheralManager.swift
@@ -8,11 +8,9 @@ public class PeripheralManager: NSObject {
 
     static let singleton = PeripheralManager()
 
-    private var actualManager: CBPeripheralManager?
-    var manager: CBPeripheralManager {
-        // This force unwrap is okay
-        return actualManager!
-    }
+    private lazy var manager: CBPeripheralManager = {
+        return CBPeripheralManager(delegate: self, queue: managerQueue)
+    }()
 
     private var managerQueue = DispatchQueue.global(qos: .utility)
     var channels: [Int: L2CAPChannelManager] = [:] // psm:manager
@@ -23,11 +21,6 @@ public class PeripheralManager: NSObject {
 
     private var servicesToAdvertise: [CBMutableService] = []
     private var servicesToAdvertiseLock: NSLock = NSLock()
-
-    private override init() {
-        super.init()
-        actualManager = CBPeripheralManager(delegate: self, queue: managerQueue)
-    }
 
     public func reset() async {
         self.manager.removeAllServices()
@@ -146,8 +139,9 @@ public class PeripheralManager: NSObject {
     }
 }
 
-extension PeripheralManager: CBPeripheralManagerDelegate {
+// MARK: - CBPeripheralManagerDelegate
 
+extension PeripheralManager: CBPeripheralManagerDelegate {
     public func peripheralManager(
         _ peripheral: CBPeripheralManager,
         didOpen channel: CBL2CAPChannel?, error: (any Error)?) {


### PR DESCRIPTION
Small change to avoid asking users for permission on app launch. Currently `CBCentralManager` is created on app launch which will show the system prompt immediately.

For the app we're working on we'd rather show the permission once the user is scanning for devices. We can use `lazy` vars for these managers so they're not initialized until they're called ~> then user is asked

https://github.com/user-attachments/assets/38834f41-86d5-4626-9449-003c68596163

https://github.com/viamrobotics/viam_flutter_provisioning/tree/main/viam_example_app
Added a starting screen here so you can see the dialog only shows once we try to scan^