### PR TITLE
export ConnectedBlePeripheral

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.0.6
+
+Export ConnectedBlePeripheral for use
+
 # 0.0.5
 
 Add lazy init for Core Bluetooth managers on iOS to avoid requesting permissions on launch.

--- a/ios/blev.podspec
+++ b/ios/blev.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'blev'
-  s.version          = '0.0.5'
+  s.version          = '0.0.6'
   s.summary          = 'A Flutter plugin project for BLE (Bluetooth Low Energy) operations.'
   s.description      = <<-DESC
 A new Flutter plugin project.

--- a/lib/ble_central.dart
+++ b/lib/ble_central.dart
@@ -1,4 +1,4 @@
 /// The entrypoint for any BLE Central operations.
 library ble_central;
 
-export 'src/ble.dart' show BleCentral, BleService, BleCharacteristic, DiscoveredBlePeripheral;
+export 'src/ble.dart' show BleCentral, BleService, BleCharacteristic, DiscoveredBlePeripheral, ConnectedBlePeripheral;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: blev
 description: A flutter plugin to communicate with Bluetooth Low Energy devices.
 repository: https://github.com/viamrobotics/flutter-ble
-version: 0.0.5
+version: 0.0.6
 homepage: https://viam.com
 topics:
   - bluetooth


### PR DESCRIPTION
I think I was working with a version of `flutter-ble` that I had modified locally where I had made this change. For my package I'm working on I need to export this public class for use: 

https://github.com/viamrobotics/viam_flutter_provisioning/blob/41015146301413ab69cf8a14a2cf5a02965a167b/lib/viam_bluetooth_provisioning.dart#L61

Only noticed again after updating/reseting the version of this package to `0.0.5` 😅 