### PR TITLE
Optional name for DiscoveredBlePeripheral

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.0.7
+
+Optional name for DiscoveredBlePeripheral
+
 # 0.0.6
 
 Export ConnectedBlePeripheral for use

--- a/ios/blev.podspec
+++ b/ios/blev.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'blev'
-  s.version          = '0.0.6'
+  s.version          = '0.0.7'
   s.summary          = 'A Flutter plugin project for BLE (Bluetooth Low Energy) operations.'
   s.description      = <<-DESC
 A new Flutter plugin project.

--- a/lib/src/ble.dart
+++ b/lib/src/ble.dart
@@ -80,7 +80,7 @@ class DiscoveredBlePeripheral {
   final String id;
 
   /// The name of the peripheral for additional verification.
-  final String name;
+  final String? name;
 
   DiscoveredBlePeripheral._private(this.id, this.name);
 }
@@ -309,7 +309,7 @@ class _BlePlatform extends PlatformInterface {
     final stream = const EventChannel(centralManagerScanForPeripheralsNotificationName)
         .receiveBroadcastStream({'service_ids': serviceIds}).cast<Map<Object?, Object?>>();
     return cancelWrapper(stream.asyncMap((event) {
-      return DiscoveredBlePeripheral._private(event['id']! as String, event['name']! as String);
+      return DiscoveredBlePeripheral._private(event['id']! as String, event['name'] as String?);
     }), () => centralManagerStopScanningForPeripherals());
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: blev
 description: A flutter plugin to communicate with Bluetooth Low Energy devices.
 repository: https://github.com/viamrobotics/flutter-ble
-version: 0.0.6
+version: 0.0.7
 homepage: https://viam.com
 topics:
   - bluetooth


### PR DESCRIPTION
On iOS it returns `''` so apps on iOS don't crash. On Android the name actually can be `null` so to avoid crashing here we can also accept `null` as the name (or fallback to an empty string like iOS if that seems better). 
